### PR TITLE
LIN-455 Set `is_demo` option in all demo/tutorial notebooks

### DIFF
--- a/story/clean_up_a_messy_notebook/clean_up_a_messy_notebook.ipynb
+++ b/story/clean_up_a_messy_notebook/clean_up_a_messy_notebook.ipynb
@@ -71,7 +71,8 @@
    },
    "outputs": [],
    "source": [
-    "import lineapy"
+    "import lineapy\n",
+    "lineapy.options.set(\"is_demo\", True) # Not for normal use"
    ]
   },
   {

--- a/story/create_a_simple_pipeline/create_a_simple_pipeline.ipynb
+++ b/story/create_a_simple_pipeline/create_a_simple_pipeline.ipynb
@@ -71,7 +71,8 @@
    },
    "outputs": [],
    "source": [
-    "import lineapy"
+    "import lineapy\n",
+    "lineapy.options.set(\"is_demo\", True) # Not for normal use"
    ]
   },
   {

--- a/story/discover_and_trace_past_work/discover_and_trace_past_work.ipynb
+++ b/story/discover_and_trace_past_work/discover_and_trace_past_work.ipynb
@@ -160,7 +160,8 @@
     }
    ],
    "source": [
-    "import lineapy"
+    "import lineapy\n",
+    "lineapy.options.set(\"is_demo\", True) # Not for normal use"
    ]
   },
   {

--- a/tutorial/00_api_basics.ipynb
+++ b/tutorial/00_api_basics.ipynb
@@ -152,7 +152,9 @@
     "import os\n",
     "import lineapy\n",
     "import pandas as pd\n",
-    "import matplotlib.pyplot as plt"
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "lineapy.options.set(\"is_demo\", True) # Not for normal use"
    ]
   },
   {


### PR DESCRIPTION
A followup task from [LIN-452](https://github.com/LineaLabs/lineapy/pull/697). In short, we want to discard calls from any demo/tutorial notebooks to to have a better reflection of organic usage by users.