### PR TITLE
Replace .catalog() with .artifact_store()

### DIFF
--- a/tutorial/00_api_basics.ipynb
+++ b/tutorial/00_api_basics.ipynb
@@ -98,7 +98,7 @@
     "**Table of Contents**\n",
     "\n",
     "- [Storing an artifact with save()](#Storing-an-artifact-with-save())\n",
-    "- [Listing artifacts with catalog()](#Listing-artifacts-with-catalog())\n",
+    "- [Listing artifacts with artifact_store()](#Listing-artifacts-with-artifact_store())\n",
     "- [Retrieving an artifact with get()](#Retrieving-an-artifact-with-get())\n",
     "- [Using artifacts to build pipelines](#Using-artifacts-to-build-pipelines)"
    ]
@@ -639,7 +639,7 @@
     "id": "e6773650-b7ee-476d-8d6b-d5f765e475ea"
    },
    "source": [
-    "## Listing artifacts with `catalog()`"
+    "## Listing artifacts with `artifact_store()`"
    ]
   },
   {
@@ -649,7 +649,7 @@
     "id": "ec7dfd68-b8d5-4aa8-82ae-5c25f53c6a7a"
    },
    "source": [
-    "Of course, with time passing, we may not remember what artifacts we saved and under what names. The `catalog()` method allows us to see the list of all previously saved artifacts, like so:"
+    "Of course, with time passing, we may not remember what artifacts we saved and under what names. The `artifact_store()` method allows us to see the list of all previously saved artifacts, like so:"
    ]
   },
   {
@@ -677,7 +677,7 @@
    ],
    "source": [
     "# List all saved artifacts\n",
-    "lineapy.catalog()"
+    "lineapy.artifact_store()"
    ]
   },
   {
@@ -701,7 +701,7 @@
     "id": "HhD9Dn-HjD7F"
    },
    "source": [
-    "Note that the catalog records each artifact’s creation time, which means that multiple versions can be stored under the same artifact name. Hence, if we save `iris_diff_avg_length` artifact again, we get:\n"
+    "Note that the artifact store records each artifact’s creation time, which means that multiple versions can be stored under the same artifact name. Hence, if we save `iris_diff_avg_length` artifact again, we get:\n"
    ]
   },
   {
@@ -733,7 +733,7 @@
     "lineapy.save(diff_avg_length, \"iris_diff_avg_length\")\n",
     "\n",
     "# List all saved artifacts\n",
-    "lineapy.catalog()"
+    "lineapy.artifact_store()"
    ]
   },
   {


### PR DESCRIPTION
The `.catalog()` API had been replaced with `.artifact_store()`, so update the notebook accordingly.

***Note:*** The reason it "missed" the update is because this copy is stored and version-controlled from this `demos` repo, which is not being tested/monitored at the moment (in contrast, its [counterpart](https://github.com/LineaLabs/lineapy/blob/main/examples/tutorials/00_api_basics.ipynb) in `lineapy` repo had already been updated correctly). We may want to set up some testing for this repo as well (relevant discussion [here](https://linealabs.slack.com/archives/C0271MCTP3N/p1655390219016009)).