### PR TITLE
Add a section on delete() API

### DIFF
--- a/tutorial/00_api_basics.ipynb
+++ b/tutorial/00_api_basics.ipynb
@@ -15,7 +15,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 1,
+      "execution_count": null,
       "id": "c1165f51",
       "metadata": {
         "id": "c1165f51"
@@ -55,7 +55,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 1,
+      "execution_count": null,
       "id": "c0e0c909",
       "metadata": {
         "id": "c0e0c909"
@@ -68,7 +68,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 2,
+      "execution_count": null,
       "id": "7205b9a1",
       "metadata": {
         "id": "7205b9a1"
@@ -147,7 +147,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 3,
+      "execution_count": null,
       "id": "3b37f98f-ca07-461f-9f76-eaabc4ed85b5",
       "metadata": {
         "id": "3b37f98f-ca07-461f-9f76-eaabc4ed85b5"
@@ -184,7 +184,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 4,
+      "execution_count": null,
       "id": "410e0e61-9135-4067-8fb0-3538757ac9b7",
       "metadata": {
         "id": "410e0e61-9135-4067-8fb0-3538757ac9b7"
@@ -197,7 +197,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 5,
+      "execution_count": null,
       "id": "7cc4e268-e4d4-48e3-8ae2-7f25723be3e2",
       "metadata": {
         "colab": {
@@ -448,7 +448,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 6,
+      "execution_count": null,
       "id": "d6b41fef",
       "metadata": {
         "colab": {
@@ -492,7 +492,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 7,
+      "execution_count": null,
       "id": "5dde49ae-8f40-44f9-b03f-161fbdf12af5",
       "metadata": {
         "id": "5dde49ae-8f40-44f9-b03f-161fbdf12af5"
@@ -514,7 +514,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 8,
+      "execution_count": null,
       "id": "05473239-4552-4edb-ab9c-58ae8875a2e4",
       "metadata": {
         "colab": {
@@ -565,7 +565,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 9,
+      "execution_count": null,
       "id": "0cf4a382-6a38-4e3e-8134-ef867a6150f5",
       "metadata": {
         "colab": {
@@ -609,7 +609,7 @@
         "outputId": "b9fc4ef1-dbb0-4a1a-c8e3-b66d71feb138"
       },
       "id": "igCWa56SqK0R",
-      "execution_count": 10,
+      "execution_count": null,
       "outputs": [
         {
           "output_type": "stream",
@@ -637,7 +637,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 11,
+      "execution_count": null,
       "id": "dbb3ebd5-6979-489f-ae28-4fff9165928f",
       "metadata": {
         "colab": {
@@ -676,7 +676,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 12,
+      "execution_count": null,
       "id": "20204203-363c-46c9-a976-8ac74ffd9e96",
       "metadata": {
         "colab": {
@@ -769,7 +769,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 13,
+      "execution_count": null,
       "id": "abd4ab03-2e9d-4416-bb68-cd2f76894cbc",
       "metadata": {
         "colab": {
@@ -830,7 +830,7 @@
         "id": "ED5t3dUpq0RL"
       },
       "id": "ED5t3dUpq0RL",
-      "execution_count": 14,
+      "execution_count": null,
       "outputs": []
     },
     {
@@ -847,7 +847,7 @@
         "outputId": "2df69016-88ff-4fca-9359-7a452e397c94"
       },
       "id": "CTgAyzIXq1P9",
-      "execution_count": 15,
+      "execution_count": null,
       "outputs": [
         {
           "output_type": "execute_result",
@@ -888,7 +888,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 16,
+      "execution_count": null,
       "id": "6978f92f-2488-45e4-aebb-707f0113c065",
       "metadata": {
         "id": "6978f92f-2488-45e4-aebb-707f0113c065"
@@ -923,7 +923,7 @@
         "outputId": "499f7718-6185-4146-d21b-eb89303af471"
       },
       "id": "PMoF5p1wrXh8",
-      "execution_count": 17,
+      "execution_count": null,
       "outputs": [
         {
           "output_type": "stream",
@@ -948,7 +948,7 @@
         "outputId": "3e88e4cd-f6ef-4ac1-c97a-77b8d4d83979"
       },
       "id": "acYL_EdlrXrM",
-      "execution_count": 18,
+      "execution_count": null,
       "outputs": [
         {
           "output_type": "stream",
@@ -973,7 +973,7 @@
         "outputId": "211943aa-513e-4a11-ed37-63f50a5f923b"
       },
       "id": "ixAnfRJLrhgV",
-      "execution_count": 19,
+      "execution_count": null,
       "outputs": [
         {
           "output_type": "stream",
@@ -1013,7 +1013,7 @@
         "id": "RqoqSLszsbo_"
       },
       "id": "RqoqSLszsbo_",
-      "execution_count": 20,
+      "execution_count": null,
       "outputs": []
     },
     {
@@ -1030,7 +1030,7 @@
         "outputId": "babe7d11-1cac-411d-a490-d5fa90fe64e9"
       },
       "id": "J8aD9sixscn5",
-      "execution_count": 21,
+      "execution_count": null,
       "outputs": [
         {
           "output_type": "stream",
@@ -1055,7 +1055,7 @@
         "outputId": "8ae6ebea-4113-4938-f42c-f212f4e28453"
       },
       "id": "i0PTuPfWscqV",
-      "execution_count": 22,
+      "execution_count": null,
       "outputs": [
         {
           "output_type": "stream",
@@ -1080,7 +1080,7 @@
         "outputId": "ca79012c-7ced-49a8-f000-dd512f2b073a"
       },
       "id": "jIaffVG8scsv",
-      "execution_count": 23,
+      "execution_count": null,
       "outputs": [
         {
           "output_type": "stream",
@@ -1133,7 +1133,7 @@
         "outputId": "682e7c42-21e8-4eff-e279-cf606e2c9de7"
       },
       "id": "T_fWRX3YTffN",
-      "execution_count": 24,
+      "execution_count": null,
       "outputs": [
         {
           "output_type": "execute_result",
@@ -1173,7 +1173,7 @@
         "outputId": "72e4cf9b-70f5-45e8-ee54-f38f489d6794"
       },
       "id": "vEaUnwyZTfvm",
-      "execution_count": 25,
+      "execution_count": null,
       "outputs": [
         {
           "output_type": "display_data",
@@ -1214,7 +1214,7 @@
         "outputId": "031febfc-1688-4bc9-b6a0-8fa5da65de66"
       },
       "id": "kaXn_paKTf1l",
-      "execution_count": 26,
+      "execution_count": null,
       "outputs": [
         {
           "output_type": "execute_result",
@@ -1227,6 +1227,18 @@
           "execution_count": 26
         }
       ]
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "Note that we can also pass a string value to `version`:\n",
+        "- `version=\"latest\"` will delete the latest version of the artifact\n",
+        "- `version=\"all\"` will delete all versions of the artifact"
+      ],
+      "metadata": {
+        "id": "HOybVJCrviL8"
+      },
+      "id": "HOybVJCrviL8"
     },
     {
       "cell_type": "markdown",
@@ -1250,7 +1262,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 27,
+      "execution_count": null,
       "id": "rZmJlpmCqg9A",
       "metadata": {
         "id": "rZmJlpmCqg9A"
@@ -1277,7 +1289,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 28,
+      "execution_count": null,
       "id": "78c8cade",
       "metadata": {
         "colab": {
@@ -1401,7 +1413,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 29,
+      "execution_count": null,
       "id": "168dbbe5",
       "metadata": {
         "colab": {
@@ -1457,7 +1469,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 30,
+      "execution_count": null,
       "id": "JYwfiWXX1bDW",
       "metadata": {
         "colab": {
@@ -1519,7 +1531,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 31,
+      "execution_count": null,
       "id": "N4r32Qjg1hYW",
       "metadata": {
         "colab": {

--- a/tutorial/00_api_basics.ipynb
+++ b/tutorial/00_api_basics.ipynb
@@ -110,6 +110,7 @@
         "- [Storing an artifact with save()](#Storing-an-artifact-with-save())\n",
         "- [Listing artifacts with artifact_store()](#Listing-artifacts-with-artifact_store())\n",
         "- [Retrieving an artifact with get()](#Retrieving-an-artifact-with-get())\n",
+        "- [Deleting an artifact with delete()](#Deleting-an-artifact-with-delete())\n",
         "- [Using artifacts to build pipelines](#Using-artifacts-to-build-pipelines)"
       ]
     },
@@ -129,9 +130,9 @@
         "\n",
         "\n",
         "*   The import statement at the top automatically starts the tracking mechanism and initializes the database for storing metadata and artifact values if it hasn't been initialized previously\n",
-        "*   The `lineapy.save` API creates LineaArtifacts and persists them to the database.\n",
-        "*   The `lineapy.get` API enables retrieval of previously saved LineaArtifacts via `lineapy.save`.\n",
-        "*   `lineapy.to_pipeline` creates a pipeline containing >=1 LineaArtifact. The files associated with the pipeline include not only the code for computing the artifact but also the Python dependencies for the code and a Dockerfile to set up a container to run the pipeline with the right dependencies installed."
+        "*   The `lineapy.save()` API creates LineaArtifacts and persists them to the database.\n",
+        "*   The `lineapy.get()` API enables retrieval of previously saved LineaArtifacts via `lineapy.save()`.\n",
+        "*   `lineapy.to_pipeline()` creates a pipeline containing >=1 LineaArtifact. The files associated with the pipeline include not only the code for computing the artifact but also the Python dependencies for the code and a Dockerfile to set up a container to run the pipeline with the right dependencies installed."
       ]
     },
     {
@@ -204,7 +205,7 @@
           "height": 423
         },
         "id": "7cc4e268-e4d4-48e3-8ae2-7f25723be3e2",
-        "outputId": "b1909a72-3301-4e5d-b527-f1280327fe41"
+        "outputId": "d1e15dfd-ae37-4f28-8c23-34dd3d7595a0"
       },
       "outputs": [
         {
@@ -228,7 +229,7 @@
             ],
             "text/html": [
               "\n",
-              "  <div id=\"df-af598234-f1d8-4606-9e8e-eb52a0679d69\">\n",
+              "  <div id=\"df-5bea2d22-7e1b-4106-9b14-ed4df130f267\">\n",
               "    <div class=\"colab-df-container\">\n",
               "      <div>\n",
               "<style scoped>\n",
@@ -348,7 +349,7 @@
               "</table>\n",
               "<p>150 rows × 5 columns</p>\n",
               "</div>\n",
-              "      <button class=\"colab-df-convert\" onclick=\"convertToInteractive('df-af598234-f1d8-4606-9e8e-eb52a0679d69')\"\n",
+              "      <button class=\"colab-df-convert\" onclick=\"convertToInteractive('df-5bea2d22-7e1b-4106-9b14-ed4df130f267')\"\n",
               "              title=\"Convert this dataframe to an interactive table.\"\n",
               "              style=\"display:none;\">\n",
               "        \n",
@@ -399,12 +400,12 @@
               "\n",
               "      <script>\n",
               "        const buttonEl =\n",
-              "          document.querySelector('#df-af598234-f1d8-4606-9e8e-eb52a0679d69 button.colab-df-convert');\n",
+              "          document.querySelector('#df-5bea2d22-7e1b-4106-9b14-ed4df130f267 button.colab-df-convert');\n",
               "        buttonEl.style.display =\n",
               "          google.colab.kernel.accessAllowed ? 'block' : 'none';\n",
               "\n",
               "        async function convertToInteractive(key) {\n",
-              "          const element = document.querySelector('#df-af598234-f1d8-4606-9e8e-eb52a0679d69');\n",
+              "          const element = document.querySelector('#df-5bea2d22-7e1b-4106-9b14-ed4df130f267');\n",
               "          const dataTable =\n",
               "            await google.colab.kernel.invokeFunction('convertToInteractive',\n",
               "                                                     [key], {});\n",
@@ -455,7 +456,7 @@
           "height": 361
         },
         "id": "d6b41fef",
-        "outputId": "8f550b98-b71f-4281-c696-bb1c8f4ca49a"
+        "outputId": "16abd78f-761d-406e-bbc9-54f66709e074"
       },
       "outputs": [
         {
@@ -520,7 +521,7 @@
           "base_uri": "https://localhost:8080/"
         },
         "id": "05473239-4552-4edb-ab9c-58ae8875a2e4",
-        "outputId": "97177e42-8cd4-448c-dcb5-5339181d5589"
+        "outputId": "e9482a63-ff64-4558-db33-466df56775fe"
       },
       "outputs": [
         {
@@ -557,9 +558,9 @@
       "source": [
         "Say we are particularly interested in tracking the average length difference between Setosa and Virginica. For instance, we might want to use this variable later for population-level modeling of the two species.\n",
         "\n",
-        "The `save()` method allows us to store a variable's value *and* history as a data type called `LineaArtifact`. Note that `LineaArtifact` holds more than the final state of the variable &mdash; it also captures the complete development process behind the variable, which allows for full reproducibility. For more information about artifacts in LineaPy, please check the [Concepts](https://docs.lineapy.org/en/latest/fundamentals/concepts.html) section.\n",
+        "The `save()` API allows us to store a variable's value *and* history as a data type called `LineaArtifact`. Note that `LineaArtifact` holds more than the final state of the variable &mdash; it also captures the complete development process behind the variable, which allows for full reproducibility. For more information about artifacts in LineaPy, please check the [Concepts](https://docs.lineapy.org/en/latest/fundamentals/concepts.html) section.\n",
         "\n",
-        "The method requires two arguments: the variable to save and the string name to save it as. It returns the saved artifact."
+        "The API requires two arguments: the variable to save and the string name to save it as. It returns the saved artifact."
       ]
     },
     {
@@ -569,10 +570,10 @@
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/",
-          "height": 41
+          "height": 33
         },
         "id": "0cf4a382-6a38-4e3e-8134-ef867a6150f5",
-        "outputId": "c2ab235d-c799-4bd2-ada1-fcdb22cf512b"
+        "outputId": "dd8058df-39ee-449f-d935-b386755c59ff"
       },
       "outputs": [
         {
@@ -605,7 +606,7 @@
           "base_uri": "https://localhost:8080/"
         },
         "id": "igCWa56SqK0R",
-        "outputId": "103d6a32-ebde-405c-ecb5-58923d6c2680"
+        "outputId": "b9fc4ef1-dbb0-4a1a-c8e3-b66d71feb138"
       },
       "id": "igCWa56SqK0R",
       "execution_count": 10,
@@ -626,7 +627,7 @@
         "id": "a5a43371-2fc9-4c37-9d41-e7be828c10b5"
       },
       "source": [
-        "`LineaArtifact` object has two key APIs:\n",
+        "`LineaArtifact` object has two key methods:\n",
         "\n",
         "- `.get_value()` returns value of the artifact, e.g., an integer or a dataframe\n",
         "- `.get_code()` returns minimal essential code to create the value\n",
@@ -643,7 +644,7 @@
           "base_uri": "https://localhost:8080/"
         },
         "id": "dbb3ebd5-6979-489f-ae28-4fff9165928f",
-        "outputId": "25f08ba0-f9eb-435d-cd93-5a08ffc41a27"
+        "outputId": "6cff0fa4-2a47-4464-d6ba-51026fe5f767"
       },
       "outputs": [
         {
@@ -682,7 +683,7 @@
           "base_uri": "https://localhost:8080/"
         },
         "id": "20204203-363c-46c9-a976-8ac74ffd9e96",
-        "outputId": "174dd0fe-aec4-47d9-bf19-345635eb9b4a"
+        "outputId": "385be1e4-01e6-4fb6-fd95-77daf4349121"
       },
       "outputs": [
         {
@@ -763,7 +764,7 @@
         "id": "ec7dfd68-b8d5-4aa8-82ae-5c25f53c6a7a"
       },
       "source": [
-        "Of course, with time passing, we may not remember what artifacts we saved and under what names. The `artifact_store()` method allows us to see the list of all previously saved artifacts, like so:"
+        "Of course, with time passing, we may not remember what artifacts we saved and under what names. The `artifact_store()` API allows us to see the list of all previously saved artifacts, like so:"
       ]
     },
     {
@@ -775,14 +776,14 @@
           "base_uri": "https://localhost:8080/"
         },
         "id": "abd4ab03-2e9d-4416-bb68-cd2f76894cbc",
-        "outputId": "8c8f5674-ac12-42f2-dc4c-7e70284b75d6"
+        "outputId": "ef618f48-f47d-406c-fafb-d17ca787da8a"
       },
       "outputs": [
         {
           "output_type": "execute_result",
           "data": {
             "text/plain": [
-              "iris_diff_avg_length:0 created on 2022-06-30 13:14:56.225311"
+              "iris_diff_avg_length:0 created on 2022-07-05 15:06:19.571205"
             ]
           },
           "metadata": {},
@@ -843,7 +844,7 @@
           "base_uri": "https://localhost:8080/"
         },
         "id": "CTgAyzIXq1P9",
-        "outputId": "47ad9641-f103-48cf-8f32-6fea26e64f23"
+        "outputId": "2df69016-88ff-4fca-9359-7a452e397c94"
       },
       "id": "CTgAyzIXq1P9",
       "execution_count": 15,
@@ -852,8 +853,8 @@
           "output_type": "execute_result",
           "data": {
             "text/plain": [
-              "iris_diff_avg_length:0 created on 2022-06-30 13:14:56.225311\n",
-              "iris_diff_avg_length:1 created on 2022-06-30 13:14:57.132521"
+              "iris_diff_avg_length:0 created on 2022-07-05 15:06:19.571205\n",
+              "iris_diff_avg_length:1 created on 2022-07-05 15:06:21.342971"
             ]
           },
           "metadata": {},
@@ -878,11 +879,11 @@
         "id": "fd81dfc3-293e-4cb9-b4f1-109232cb6dc3"
       },
       "source": [
-        "We can retrieve any stored artifact using the `get()` method. This comes in handy when we work across multiple sessions/phases of a project (or even across different projects) as we can easily build on the previous work.\n",
+        "We can retrieve any stored artifact using the `get()` API. This comes in handy when we work across multiple sessions/phases of a project (or even across different projects) as we can easily build on the previous work.\n",
         "\n",
-        "For example, say we have done other exploratory analyses and are finally starting our work on population-level modeling. This is likely done in a new Jupyter notebook (possibly in a different subdirectory) and we need an easy way to load artifacts from our past work. We can use the `get()` method for this.\n",
+        "For example, say we have done other exploratory analyses and are finally starting our work on population-level modeling. This is likely done in a new Jupyter notebook (possibly in a different subdirectory) and we need an easy way to load artifacts from our past work. We can use the `get()` API for this.\n",
         "\n",
-        "The method takes the string name of the artifact as its argument and returns the corresponding artifact, like so:"
+        "The API takes the string name of the artifact as its argument and returns the corresponding artifact, like so:"
       ]
     },
     {
@@ -901,7 +902,7 @@
     {
       "cell_type": "markdown",
       "source": [
-        "By default, the `get()` method retrieves the latest version of the given artifact."
+        "By default, the `get()` API retrieves the latest version of the given artifact."
       ],
       "metadata": {
         "id": "G0_TYaMtro8t"
@@ -919,7 +920,7 @@
           "base_uri": "https://localhost:8080/"
         },
         "id": "PMoF5p1wrXh8",
-        "outputId": "18bf7ec9-9f33-4be2-fb41-d8e5c31aad34"
+        "outputId": "499f7718-6185-4146-d21b-eb89303af471"
       },
       "id": "PMoF5p1wrXh8",
       "execution_count": 17,
@@ -944,7 +945,7 @@
           "base_uri": "https://localhost:8080/"
         },
         "id": "acYL_EdlrXrM",
-        "outputId": "30a4eabe-2761-4c40-bdb2-e0fb8462016d"
+        "outputId": "3e88e4cd-f6ef-4ac1-c97a-77b8d4d83979"
       },
       "id": "acYL_EdlrXrM",
       "execution_count": 18,
@@ -969,7 +970,7 @@
           "base_uri": "https://localhost:8080/"
         },
         "id": "ixAnfRJLrhgV",
-        "outputId": "1d40ab90-79c1-44be-e2a5-878393f1e3c6"
+        "outputId": "211943aa-513e-4a11-ed37-63f50a5f923b"
       },
       "id": "ixAnfRJLrhgV",
       "execution_count": 19,
@@ -1026,7 +1027,7 @@
           "base_uri": "https://localhost:8080/"
         },
         "id": "J8aD9sixscn5",
-        "outputId": "8870f5af-6469-4ad7-ccae-b6ae4f58b87b"
+        "outputId": "babe7d11-1cac-411d-a490-d5fa90fe64e9"
       },
       "id": "J8aD9sixscn5",
       "execution_count": 21,
@@ -1051,7 +1052,7 @@
           "base_uri": "https://localhost:8080/"
         },
         "id": "i0PTuPfWscqV",
-        "outputId": "bad4913f-1e86-426f-ae4e-c001eac4b9bb"
+        "outputId": "8ae6ebea-4113-4938-f42c-f212f4e28453"
       },
       "id": "i0PTuPfWscqV",
       "execution_count": 22,
@@ -1076,7 +1077,7 @@
           "base_uri": "https://localhost:8080/"
         },
         "id": "jIaffVG8scsv",
-        "outputId": "952d8906-c158-41f6-a4b6-53994d78aa4f"
+        "outputId": "ca79012c-7ced-49a8-f000-dd512f2b073a"
       },
       "id": "jIaffVG8scsv",
       "execution_count": 23,
@@ -1095,6 +1096,135 @@
             "diff_avg_length = avg_length_setosa - avg_length_virginica\n",
             "\n"
           ]
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "## Deleting an artifact with `delete()`"
+      ],
+      "metadata": {
+        "id": "ZwJAfla_TVVu"
+      },
+      "id": "ZwJAfla_TVVu"
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "With time passing, it is likely that the artifact store contains many artifacts, including some that we no longer need/want. We can use the `delete()` API to remove such undesired artifacts. For instance, we currently have two versions of `iris_diff_avg_length` artifact, like so:"
+      ],
+      "metadata": {
+        "id": "gWmJPCEFTfIO"
+      },
+      "id": "gWmJPCEFTfIO"
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "# List all saved artifacts\n",
+        "lineapy.artifact_store()"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "T_fWRX3YTffN",
+        "outputId": "682e7c42-21e8-4eff-e279-cf606e2c9de7"
+      },
+      "id": "T_fWRX3YTffN",
+      "execution_count": 24,
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "iris_diff_avg_length:0 created on 2022-07-05 15:06:19.571205\n",
+              "iris_diff_avg_length:1 created on 2022-07-05 15:06:21.342971"
+            ]
+          },
+          "metadata": {},
+          "execution_count": 24
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "Let's say we no longer need version `1`. We can remove it by calling the `delete()` API with the artifact name and version, as the following:"
+      ],
+      "metadata": {
+        "id": "OEyBs3F31PbB"
+      },
+      "id": "OEyBs3F31PbB"
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "# Delete a specific artifact\n",
+        "lineapy.delete(\"iris_diff_avg_length\", version=1)"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 33
+        },
+        "id": "vEaUnwyZTfvm",
+        "outputId": "72e4cf9b-70f5-45e8-ee54-f38f489d6794"
+      },
+      "id": "vEaUnwyZTfvm",
+      "execution_count": 25,
+      "outputs": [
+        {
+          "output_type": "display_data",
+          "data": {
+            "text/plain": [
+              "Deleted Artifact: iris_diff_avg_length version: \u001b[1;36m1\u001b[0m                                            \n"
+            ],
+            "text/html": [
+              "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">Deleted Artifact: iris_diff_avg_length version: <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">1</span>                                            \n",
+              "</pre>\n"
+            ]
+          },
+          "metadata": {}
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "If we check the artifact store again, we no longer see the artifact:"
+      ],
+      "metadata": {
+        "id": "206YEtcZ34Sy"
+      },
+      "id": "206YEtcZ34Sy"
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "# List all saved artifacts\n",
+        "lineapy.artifact_store()"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "kaXn_paKTf1l",
+        "outputId": "031febfc-1688-4bc9-b6a0-8fa5da65de66"
+      },
+      "id": "kaXn_paKTf1l",
+      "execution_count": 26,
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "iris_diff_avg_length:0 created on 2022-07-05 15:06:19.571205"
+            ]
+          },
+          "metadata": {},
+          "execution_count": 26
         }
       ]
     },
@@ -1120,7 +1250,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 24,
+      "execution_count": 27,
       "id": "rZmJlpmCqg9A",
       "metadata": {
         "id": "rZmJlpmCqg9A"
@@ -1147,15 +1277,15 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 25,
+      "execution_count": 28,
       "id": "78c8cade",
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/",
-          "height": 155
+          "height": 115
         },
         "id": "78c8cade",
-        "outputId": "142759fd-6409-4a61-eecd-dee9b1a1aec9"
+        "outputId": "da7025bb-9bb8-4c7e-ea49-10f6af6dd488"
       },
       "outputs": [
         {
@@ -1231,7 +1361,7 @@
             ]
           },
           "metadata": {},
-          "execution_count": 25
+          "execution_count": 28
         }
       ],
       "source": [
@@ -1271,14 +1401,14 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 26,
+      "execution_count": 29,
       "id": "168dbbe5",
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
         "id": "168dbbe5",
-        "outputId": "46b6330b-8a50-4b3a-df97-9c80db416a1d"
+        "outputId": "22b6ae18-e036-43ac-e798-349b96854bb5"
       },
       "outputs": [
         {
@@ -1286,13 +1416,13 @@
           "data": {
             "text/plain": [
               "['demo_pipeline_dag.py',\n",
+              " 'demo_pipeline.py',\n",
               " 'demo_pipeline_Dockerfile',\n",
-              " 'demo_pipeline_requirements.txt',\n",
-              " 'demo_pipeline.py']"
+              " 'demo_pipeline_requirements.txt']"
             ]
           },
           "metadata": {},
-          "execution_count": 26
+          "execution_count": 29
         }
       ],
       "source": [
@@ -1327,14 +1457,14 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 27,
+      "execution_count": 30,
       "id": "JYwfiWXX1bDW",
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
         "id": "JYwfiWXX1bDW",
-        "outputId": "c7ad508d-e9ed-4747-bf66-b226875c99af"
+        "outputId": "5de9972e-0dc8-4473-91b3-6a50fe747d37"
       },
       "outputs": [
         {
@@ -1354,8 +1484,7 @@
             "    avg_length_setosa = df.query(\"variety == 'Setosa'\")[\"petal.length\"].mean()\n",
             "    avg_length_virginica = df.query(\"variety == 'Virginica'\")[\"petal.length\"].mean()\n",
             "    diff_avg_length = avg_length_setosa - avg_length_virginica\n",
-            "    diff_avg_length_updated = diff_avg_length + 1\n",
-            "    length_artifact = pickle.dump(diff_avg_length_updated, open(\"f2aVQoH.pkl\", \"wb\"))\n",
+            "    length_artifact = pickle.dump(diff_avg_length, open(\"ZBW0iNt.pkl\", \"wb\"))\n",
             "\n",
             "\n",
             "def iris_diff_avg_width():\n",
@@ -1368,7 +1497,7 @@
             "    avg_width_setosa = df.query(\"variety == 'Setosa'\")[\"petal.width\"].mean()\n",
             "    avg_width_virginica = df.query(\"variety == 'Virginica'\")[\"petal.width\"].mean()\n",
             "    diff_avg_width = avg_width_setosa - avg_width_virginica\n",
-            "    width_artifact = pickle.dump(diff_avg_width, open(\"fmF8vKR.pkl\", \"wb\"))\n"
+            "    width_artifact = pickle.dump(diff_avg_width, open(\"VOkvYIy.pkl\", \"wb\"))\n"
           ]
         }
       ],
@@ -1390,14 +1519,14 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 28,
+      "execution_count": 31,
       "id": "N4r32Qjg1hYW",
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
         "id": "N4r32Qjg1hYW",
-        "outputId": "418b0535-1b50-4fd3-ae26-ece273334745"
+        "outputId": "dc65c41c-0128-484c-845c-a2305182399b"
       },
       "outputs": [
         {
@@ -1468,7 +1597,7 @@
   "metadata": {
     "colab": {
       "collapsed_sections": [],
-      "name": "Copy of 00_api_basics.ipynb",
+      "name": "00_api_basics.ipynb",
       "provenance": []
     },
     "interpreter": {


### PR DESCRIPTION
The `delete()` API has been recently added to our package distribution but we have not added relevant instructions in our API basics tutorial. This PR adds a section for that.

Plus, this PR also includes some changes to use terms more consistently. Specifically, we will call `lineapy` functions (e.g., `lineapy.save()`) as `API`s instead of `method`s.